### PR TITLE
distribution_corner_case

### DIFF
--- a/R/custom_function.R
+++ b/R/custom_function.R
@@ -41,11 +41,23 @@ circular_mean <- function (value, coverage_fraction) {
 
 distribution = function(value, coverage_fraction, breaks = 10, constrain = FALSE){
 
+  if (length(value) <= 0 | all(is.nan(value))) {
+    return("[]")
+  }
+
   x1 = value*coverage_fraction
   x1 = x1[!is.na(x1)]
 
   if(constrain | length(breaks) > 1){
+
+    breaks_tmp = c(breaks[1],breaks[2])
+
     breaks = breaks[!breaks > max(x1, na.rm = TRUE)]
+
+    if (length(breaks) == 1){
+      breaks = breaks_tmp
+      }
+
   }
 
   tmp = as.data.frame(table(cut(x1, breaks = breaks)))


### PR DESCRIPTION
The PR fixed a corner case where the size of the 'first break' is smaller than the user-provided size. An example of this occurred when computing GIUH (with breaks set at intervals 0, 60, 120, 180,... [in minutes]). In cases where catchments are too small and can drain in less than 60 minutes, the modified code ensures to return the `first break` that the user provided.