### PR TITLE
bugs_in_distribution

### DIFF
--- a/R/custom_function.R
+++ b/R/custom_function.R
@@ -63,7 +63,13 @@ distribution = function(value, coverage_fraction, breaks = 10, constrain = FALSE
 
     breaks_tmp = c(breaks[1],breaks[2])
 
-    breaks = breaks[!breaks > max(x1, na.rm = TRUE)]
+    ulimit = max(x1, na.rm = TRUE)
+    
+    if (ulimit < max(breaks, na.rm = TRUE)){
+       ulimit = min(breaks[breaks >= ulimit])
+    }
+
+    breaks = breaks[breaks <= ulimit]
 
     if (length(breaks) == 1){
       breaks = breaks_tmp

--- a/R/custom_function.R
+++ b/R/custom_function.R
@@ -59,7 +59,7 @@ distribution = function(value, coverage_fraction, breaks = 10, constrain = FALSE
   x1 = value*coverage_fraction
   x1 = x1[!is.na(x1)]
 
-  if(constrain | length(breaks) > 1){
+  if(constrain & length(breaks) > 1){
 
     breaks_tmp = c(breaks[1],breaks[2])
 


### PR DESCRIPTION
The PR fixes two issues in the zonal::distribution

1. `if(constrain | length(breaks) > 1)` should be `if(constrain **&** length(breaks) > 1)` otherwise this block executives even when `constrain = FALSE` as `length(breaks)` is always > 0.
2. Issues with cutting off values that are within the limits of breaks. The current behavior is, for instance,
  `x1=c(50, 100, 150, 200, 250, 280, 290)` and `breaks = seq(0.0, 600, by=60)` gives

```
     Var1      Freq
1    (0,60]    1
2  (60,120]    1
3 (120,180]    1
4 (180,240]    1
```
ignoring the values 280 and 290, while the expected behavior should be

```
       Var1      Freq
1    (0,60]      1
2  (60,120]      1
3 (120,180]      1
4 (180,240]      1
5 (240,300]      3
```